### PR TITLE
fix: add missing __init__.py

### DIFF
--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,6 +1,6 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 default_app_config = "openedx_ledger.apps.EdxLedgerConfig"

--- a/openedx_ledger/api.py
+++ b/openedx_ledger/api.py
@@ -22,7 +22,8 @@ def create_transaction(
     with atomic(durable=True):
         balance = ledger.balance()
         if (quantity < 0) and ((balance + quantity) < 0):
-            raise Exception("d'oh!")
+            # TODO: we definitely have to revisit this logic later to implement ADR 0002.
+            raise Exception("d'oh!")  # pylint: disable=broad-exception-raised
 
         transaction, _ = models.Transaction.objects.get_or_create(
             ledger=ledger,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,13 +16,13 @@ cffi==1.15.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via edx-django-utils
-cryptography==39.0.0
+cryptography==39.0.2
     # via pyjwt
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -70,7 +70,7 @@ edx-django-utils==5.2.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
-edx-drf-extensions==8.4.0
+edx-drf-extensions==8.4.1
     # via edx-rbac
 edx-opaque-keys[django]==2.3.0
     # via
@@ -78,9 +78,9 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 edx-rbac==1.7.0
     # via -r requirements/base.in
-fastavro==1.7.0
+fastavro==1.7.2
     # via openedx-events
-future==0.18.2
+future==0.18.3
     # via pyjwkest
 idna==3.4
     # via requests
@@ -88,11 +88,11 @@ jsonfield2==4.0.0.post0
     # via -r requirements/base.in
 mysqlclient==2.1.1
     # via -r requirements/base.in
-newrelic==8.5.0
+newrelic==8.7.0
     # via edx-django-utils
-openedx-events==4.1.0
+openedx-events==6.0.0
     # via -r requirements/base.in
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
 ply==3.11
     # via djangoql
@@ -100,7 +100,7 @@ psutil==5.9.4
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.16.0
+pycryptodomex==3.17
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
@@ -114,16 +114,16 @@ pynacl==1.5.0
     # via edx-django-utils
 python-dateutil==2.8.2
     # via edx-drf-extensions
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/base.in
     #   django
     #   djangorestframework
 pyyaml==6.0
     # via edx-django-release-util
-redis==4.4.0
+redis==4.5.1
     # via -r requirements/base.in
-requests==2.28.1
+requests==2.28.2
     # via
     #   edx-drf-extensions
     #   pyjwkest
@@ -140,9 +140,9 @@ six==1.16.0
     #   python-dateutil
 sqlparse==0.4.3
     # via django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,11 +6,11 @@
 #
 certifi==2022.12.7
     # via requests
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==7.0.3
+coverage==7.2.1
     # via codecov
 distlib==0.3.6
     # via virtualenv
@@ -20,15 +20,15 @@ filelock==3.9.0
     #   virtualenv
 idna==3.4
     # via requests
-packaging==22.0
+packaging==23.0
     # via tox
-platformdirs==2.6.2
+platformdirs==3.1.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.1
+requests==2.28.2
     # via codecov
 six==1.16.0
     # via tox
@@ -41,7 +41,7 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.13
+urllib3==1.26.14
     # via requests
-virtualenv==20.17.1
+virtualenv==20.20.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.12.13
+astroid==2.15.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -22,7 +22,7 @@ attrs==22.2.0
     #   -r requirements/quality.txt
     #   openedx-events
     #   pytest
-build==0.9.0
+build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -38,7 +38,7 @@ cffi==1.15.1
     #   pynacl
 chardet==5.1.0
     # via diff-cover
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -62,17 +62,17 @@ code-annotations==1.3.0
     #   edx-lint
 codecov==2.1.12
     # via -r requirements/ci.txt
-coverage[toml]==7.0.3
+coverage[toml]==7.2.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.2
     # via
     #   -r requirements/quality.txt
     #   pyjwt
-diff-cover==7.3.0
+diff-cover==7.5.0
     # via -r requirements/dev.in
 dill==0.3.6
     # via
@@ -82,7 +82,7 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -138,13 +138,13 @@ edx-django-utils==5.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-drf-extensions
-edx-drf-extensions==8.4.0
+edx-drf-extensions==8.4.1
     # via
     #   -r requirements/quality.txt
     #   edx-rbac
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
-edx-lint==5.3.0
+edx-lint==5.3.2
     # via -r requirements/quality.txt
 edx-opaque-keys[django]==2.3.0
     # via
@@ -157,7 +157,13 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-fastavro==1.7.0
+factory-boy==3.2.1
+    # via -r requirements/quality.txt
+faker==17.6.0
+    # via
+    #   -r requirements/quality.txt
+    #   factory-boy
+fastavro==1.7.2
     # via
     #   -r requirements/quality.txt
     #   openedx-events
@@ -166,7 +172,7 @@ filelock==3.9.0
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-future==0.18.2
+future==0.18.3
     # via
     #   -r requirements/quality.txt
     #   pyjwkest
@@ -175,11 +181,11 @@ idna==3.4
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.11.4
+isort==5.12.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -194,7 +200,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/quality.txt
     #   astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/quality.txt
     #   jinja2
@@ -204,13 +210,13 @@ mccabe==0.7.0
     #   pylint
 mysqlclient==2.1.1
     # via -r requirements/quality.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-openedx-events==4.1.0
+openedx-events==6.0.0
     # via -r requirements/quality.txt
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -220,17 +226,13 @@ packaging==22.0
     #   tox
 path==16.6.0
     # via edx-i18n-tools
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.13.0
-    # via
-    #   -r requirements/pip-tools.txt
-    #   build
-pip-tools==6.12.1
+pip-tools==6.12.3
     # via -r requirements/pip-tools.txt
-platformdirs==2.6.2
+platformdirs==3.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -247,7 +249,7 @@ ply==3.11
     # via
     #   -r requirements/quality.txt
     #   djangoql
-polib==1.1.1
+polib==1.2.0
     # via edx-i18n-tools
 psutil==5.9.4
     # via
@@ -263,11 +265,11 @@ pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pycryptodomex==3.16.0
+pycryptodomex==3.17
     # via
     #   -r requirements/quality.txt
     #   pyjwkest
-pydocstyle==6.2.2
+pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.14.0
     # via diff-cover
@@ -280,7 +282,7 @@ pyjwt[crypto]==2.6.0
     #   -r requirements/quality.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.15.9
+pylint==2.16.4
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -308,7 +310,11 @@ pynacl==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
-pytest==7.2.0
+pyproject-hooks==1.0.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   build
+pytest==7.2.2
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -321,11 +327,12 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/quality.txt
     #   edx-drf-extensions
-python-slugify==7.0.0
+    #   faker
+python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/quality.txt
     #   django
@@ -336,9 +343,9 @@ pyyaml==6.0
     #   code-annotations
     #   edx-django-release-util
     #   edx-i18n-tools
-redis==4.4.0
+redis==4.5.1
     # via -r requirements/quality.txt
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -370,7 +377,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -387,8 +394,8 @@ tomli==2.0.1
     #   -r requirements/quality.txt
     #   build
     #   coverage
-    #   pep517
     #   pylint
+    #   pyproject-hooks
     #   pytest
     #   tox
 tomlkit==0.11.6
@@ -402,17 +409,17 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.17.1
+virtualenv==20.20.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -420,7 +427,7 @@ wheel==0.38.4
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
 asgiref==3.6.0
     # via
@@ -19,11 +19,11 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   openedx-events
     #   pytest
-babel==2.11.0
+babel==2.12.1
     # via sphinx
-bleach==5.0.1
+bleach==6.0.0
     # via readme-renderer
-build==0.9.0
+build==0.10.0
     # via -r requirements/doc.in
 certifi==2022.12.7
     # via
@@ -34,7 +34,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/test.txt
     #   requests
@@ -45,18 +45,16 @@ click==8.1.3
     #   edx-django-utils
 code-annotations==1.3.0
     # via -r requirements/test.txt
-commonmark==0.9.1
-    # via rich
-coverage[toml]==7.0.3
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.2
     # via
     #   -r requirements/test.txt
     #   pyjwt
     #   secretstorage
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -119,7 +117,7 @@ edx-django-utils==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-drf-extensions==8.4.0
+edx-drf-extensions==8.4.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
@@ -130,17 +128,23 @@ edx-opaque-keys[django]==2.3.0
     #   openedx-events
 edx-rbac==1.7.0
     # via -r requirements/test.txt
-edx-sphinx-theme==3.0.0
+edx-sphinx-theme==3.1.0
     # via -r requirements/doc.in
 exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-fastavro==1.7.0
+factory-boy==3.2.1
+    # via -r requirements/test.txt
+faker==17.6.0
+    # via
+    #   -r requirements/test.txt
+    #   factory-boy
+fastavro==1.7.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-future==0.18.2
+future==0.18.3
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -155,9 +159,9 @@ importlib-metadata==6.0.0
     #   keyring
     #   sphinx
     #   twine
-importlib-resources==5.10.2
+importlib-resources==5.12.0
     # via keyring
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -176,33 +180,35 @@ jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
 keyring==23.13.1
     # via twine
-markupsafe==2.1.1
+markdown-it-py==2.2.0
+    # via rich
+markupsafe==2.1.2
     # via
     #   -r requirements/test.txt
     #   jinja2
-more-itertools==9.0.0
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==9.1.0
     # via jaraco-classes
 mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==4.1.0
+openedx-events==6.0.0
     # via -r requirements/test.txt
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/test.txt
     #   build
     #   pytest
     #   sphinx
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pep517==0.13.0
-    # via build
-pkginfo==1.9.3
+pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via
@@ -220,7 +226,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.16.0
+pycryptodomex==3.17
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -247,7 +253,9 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.0
+pyproject-hooks==1.0.0
+    # via build
+pytest==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -260,11 +268,12 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-python-slugify==7.0.0
+    #   faker
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/test.txt
     #   babel
@@ -277,9 +286,9 @@ pyyaml==6.0
     #   edx-django-release-util
 readme-renderer==37.3
     # via twine
-redis==4.4.0
+redis==4.5.1
     # via -r requirements/test.txt
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -293,7 +302,7 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.0.0
+rich==13.3.2
     # via twine
 rules==3.3
     # via -r requirements/test.txt
@@ -315,15 +324,16 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==6.0.0
+sphinx==5.3.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/doc.in
     #   edx-sphinx-theme
-sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -335,7 +345,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -352,20 +362,20 @@ tomli==2.0.1
     #   build
     #   coverage
     #   doc8
-    #   pep517
+    #   pyproject-hooks
     #   pytest
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via rich
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/test.txt
     #   requests
     #   twine
 webencodings==0.5.1
     # via bleach
-zipp==3.11.0
+zipp==3.15.0
     # via
     #   importlib-metadata
     #   importlib-resources

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,20 +4,18 @@
 #
 #    make upgrade
 #
-build==0.9.0
+build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==22.0
+packaging==23.0
     # via build
-pep517==0.13.0
-    # via build
-pip-tools==6.12.1
+pip-tools==6.12.3
     # via -r requirements/pip-tools.in
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
+    # via build
 wheel==0.38.4
     # via pip-tools
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,9 @@
 #
 #    make upgrade
 #
-pip==22.3.1
+pip==23.0.1
     # via -r requirements/pip.in
-setuptools==59.8.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   -r requirements/pip.in
+setuptools==67.5.1
+    # via -r requirements/pip.in
 wheel==0.38.4
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.12.13
+astroid==2.15.0
     # via
     #   pylint
     #   pylint-celery
@@ -30,7 +30,7 @@ cffi==1.15.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/test.txt
     #   requests
@@ -47,17 +47,17 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.0.3
+coverage[toml]==7.2.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==39.0.0
+cryptography==39.0.2
     # via
     #   -r requirements/test.txt
     #   pyjwt
 dill==0.3.6
     # via pylint
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -112,11 +112,11 @@ edx-django-utils==5.2.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-edx-drf-extensions==8.4.0
+edx-drf-extensions==8.4.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==5.3.0
+edx-lint==5.3.2
     # via -r requirements/quality.in
 edx-opaque-keys[django]==2.3.0
     # via
@@ -129,11 +129,17 @@ exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-fastavro==1.7.0
+factory-boy==3.2.1
+    # via -r requirements/test.txt
+faker==17.6.0
+    # via
+    #   -r requirements/test.txt
+    #   factory-boy
+fastavro==1.7.2
     # via
     #   -r requirements/test.txt
     #   openedx-events
-future==0.18.2
+future==0.18.3
     # via
     #   -r requirements/test.txt
     #   pyjwkest
@@ -141,11 +147,11 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.11.4
+isort==5.12.0
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -157,7 +163,7 @@ jsonfield2==4.0.0.post0
     # via -r requirements/test.txt
 lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/test.txt
     #   jinja2
@@ -165,21 +171,21 @@ mccabe==0.7.0
     # via pylint
 mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-openedx-events==4.1.0
+openedx-events==6.0.0
     # via -r requirements/test.txt
-packaging==22.0
+packaging==23.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.2
+platformdirs==3.1.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -199,11 +205,11 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.16.0
+pycryptodomex==3.17
     # via
     #   -r requirements/test.txt
     #   pyjwkest
-pydocstyle==6.2.2
+pydocstyle==6.3.0
     # via -r requirements/quality.in
 pyjwkest==1.4.2
     # via
@@ -214,7 +220,7 @@ pyjwt[crypto]==2.6.0
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.15.9
+pylint==2.16.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -236,7 +242,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.0
+pytest==7.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -249,11 +255,12 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-python-slugify==7.0.0
+    #   faker
+python-slugify==8.0.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -263,9 +270,9 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-release-util
-redis==4.4.0
+redis==4.5.1
     # via -r requirements/test.txt
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -291,7 +298,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -309,13 +316,13 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.11.6
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/test.txt
     #   requests
-wrapt==1.14.1
+wrapt==1.15.0
     # via astroid

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 
 -r base.txt               # Core dependencies for this package
 
+code-annotations          # provides commands used by the pii_check make target.
+factory-boy
 pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
-code-annotations          # provides commands used by the pii_check make target.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,7 +26,7 @@ cffi==1.15.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via
     #   -r requirements/base.txt
     #   requests
@@ -37,9 +37,9 @@ click==8.1.3
     #   edx-django-utils
 code-annotations==1.3.0
     # via -r requirements/test.in
-coverage[toml]==7.0.3
+coverage[toml]==7.2.1
     # via pytest-cov
-cryptography==39.0.0
+cryptography==39.0.2
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -97,7 +97,7 @@ edx-django-utils==5.2.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-drf-extensions==8.4.0
+edx-drf-extensions==8.4.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
@@ -110,11 +110,15 @@ edx-rbac==1.7.0
     # via -r requirements/base.txt
 exceptiongroup==1.1.0
     # via pytest
-fastavro==1.7.0
+factory-boy==3.2.1
+    # via -r requirements/test.in
+faker==17.6.0
+    # via factory-boy
+fastavro==1.7.2
     # via
     #   -r requirements/base.txt
     #   openedx-events
-future==0.18.2
+future==0.18.3
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -122,25 +126,25 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via code-annotations
 jsonfield2==4.0.0.post0
     # via -r requirements/base.txt
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.5.0
+newrelic==8.7.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==4.1.0
+openedx-events==6.0.0
     # via -r requirements/base.txt
-packaging==22.0
+packaging==23.0
     # via pytest
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -158,7 +162,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.16.0
+pycryptodomex==3.17
     # via
     #   -r requirements/base.txt
     #   pyjwkest
@@ -179,7 +183,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.0
+pytest==7.2.2
     # via
     #   pytest-cov
     #   pytest-django
@@ -191,9 +195,10 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-python-slugify==7.0.0
+    #   faker
+python-slugify==8.0.1
     # via code-annotations
-pytz==2022.7
+pytz==2022.7.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -203,9 +208,9 @@ pyyaml==6.0
     #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-release-util
-redis==4.4.0
+redis==4.5.1
     # via -r requirements/base.txt
-requests==2.28.1
+requests==2.28.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -228,7 +233,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -240,7 +245,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-urllib3==1.26.13
+urllib3==1.26.14
     # via
     #   -r requirements/base.txt
     #   requests


### PR DESCRIPTION
This prevents the tests folder from being included in the pypi release.  I originally missed this because local testing with `pip install -e ../openedx-ledger` is insensitive to the absence of these files.

Notes:
* This also revealed a missing requirement (factory-boy).    
* Bump version to 0.1.5