### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,6 +1,6 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 default_app_config = "openedx_ledger.apps.EdxLedgerConfig"


### PR DESCRIPTION
I forgot to bump the version in the last PR.

ENT-6803 cont.