### PR TITLE
fix: removing the related field from the readonly fields of transaction admin

### DIFF
--- a/openedx_ledger/admin.py
+++ b/openedx_ledger/admin.py
@@ -40,6 +40,30 @@ class LedgerAdmin(SimpleHistoryAdmin):
         return obj.balance()
 
 
+@admin.register(models.ExternalFulfillmentProvider)
+class ExternalFulfillmentProviderAdmin(SimpleHistoryAdmin):
+    """
+    Admin configuration for the ExternalFulfillmentProvider model.
+    """
+    class Meta:
+        """
+        Metaclass for ExternalFulfillmentProviderAdmin.
+        """
+
+        model = models.ExternalFulfillmentProvider
+        fields = '__all__'
+
+    search_fields = ('name', 'slug',)
+    list_display = ('name', 'slug',)
+
+
+class ExternalTransactionReferenceInlineAdmin(admin.TabularInline):
+    """
+    Inline admin configuration for the ExternalTransactionReference model.
+    """
+    model = models.ExternalTransactionReference
+
+
 @admin.register(models.Transaction)
 class TransactionAdmin(SimpleHistoryAdmin):
     """
@@ -55,7 +79,7 @@ class TransactionAdmin(SimpleHistoryAdmin):
         fields = '__all__'
 
     search_fields = ('content_key', 'lms_user_id', 'uuid', 'external_reference__external_reference_id',)
-    _all_fields = [field.name for field in models.Transaction._meta.get_fields()]
+    _all_fields = [field.name for field in models.Transaction._meta.get_fields() if field.name != 'external_reference']
     list_display = ('uuid', 'idempotency_key', 'quantity', 'state',)
     if can_modify():
         readonly_fields = (
@@ -64,6 +88,7 @@ class TransactionAdmin(SimpleHistoryAdmin):
         )
     else:
         readonly_fields = _all_fields
+    inlines = [ExternalTransactionReferenceInlineAdmin]
 
 
 @admin.register(models.Reversal)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67655836/230498680-81c83ebd-9e83-4970-8940-145e79a9ff71.png)

**Description:**
adds external fulfillment provider admin as well as fixes the inclusion of external reference in the read only fields of the transaction admin, which was causing a 500 on inspection of transactions in the admin pages.  Now external references are correctly made inline fields

NOTE This does not necessarily unblock the ability to generate new transactions through the admin screen. Since many of the fields are currently readonly and the values are required, the flow still breaks if you actually hit "create"...

**Testing instructions:**
look at django admin

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
