### PR TITLE
feat: ledger signals and admin unenrollment buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ pip-log.txt
 coverage.xml
 htmlcov/
 
-
+.vscode/
 
 # The Silver Searcher
 .agignore

--- a/docs/decisions/0005-ledger-event-signals.rst
+++ b/docs/decisions/0005-ledger-event-signals.rst
@@ -1,0 +1,35 @@
+0005 LEDGER EVENT SIGNALS
+#########################
+
+Status
+******
+
+**Accepted**
+
+.. Standard statuses
+    - **Draft** if the decision is newly proposed and in active discussion
+    - **Provisional** if the decision is still preliminary and in experimental phase
+    - **Accepted** *(date)* once it is agreed upon
+    - **Superseded** *(date)* with a reference to its replacement if a later ADR changes or reverses the decision
+
+Context
+*******
+
+Consumers of the openedx-ledger need to be have the ability to perform specific actions when certain events are 
+invoked, such as a transaction reversal. The most common use case is to hook up new django signals for each needed 
+event. These signals can be used to broadcast any particular action to any and all downstream consumers. 
+
+
+Decision
+********
+
+We will use the `Django Signals` framework to provide a mechanism for consumers to hook into the transaction reversal 
+process (the successful invokation of the `reverse_full_transaction` method). We will establish a pattern of signals 
+definitions within the `signals` dir of the openedx-ledger app. Starting out, the only signal defined will be named 
+`TRANSACTION_REVERSED` and it will set the pattern for any future signal usage should the need for a change arise.
+
+Consequences
+************
+
+* Consumers of the ledger service will be able to hook into the reversal process and perform any actions they need to.
+* Patterns for signal events will be established and documented in the openedx ledger and subsidy service.

--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,6 +1,6 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 default_app_config = "openedx_ledger.apps.EdxLedgerConfig"

--- a/openedx_ledger/api.py
+++ b/openedx_ledger/api.py
@@ -4,6 +4,7 @@ The openedx_ledger python API.
 from django.db.transaction import atomic, get_connection
 
 from openedx_ledger import models, utils
+from openedx_ledger.signals.signals import TRANSACTION_REVERSED
 
 
 class LedgerBalanceExceeded(Exception):
@@ -93,6 +94,7 @@ def reverse_full_transaction(transaction, idempotency_key, **metadata):
                 'metadata': metadata,
             },
         )
+        TRANSACTION_REVERSED.send(sender=models.Reversal, reversal=reversal)
         return reversal
 
 

--- a/openedx_ledger/signals/signals.py
+++ b/openedx_ledger/signals/signals.py
@@ -1,0 +1,11 @@
+"""
+openedx_ledger related signals.
+"""
+
+from django.dispatch import Signal
+
+# Signal that indicates that a transaction object has been reversed.
+# providing_args=[
+#         'reversal',  # Reversal object
+#     ]
+TRANSACTION_REVERSED = Signal()

--- a/openedx_ledger/templates/edx_ledger/admin/reverse_transaction.html
+++ b/openedx_ledger/templates/edx_ledger/admin/reverse_transaction.html
@@ -1,0 +1,25 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static admin_urls %}
+<!-- {% load l10n %} -->
+{% block content %}
+<form action="" method="post">{% csrf_token %}
+    <h1>
+        Transaction Reversal and Unenrollment
+    </h1>
+    <h3>
+        This action will unenroll the learner AND refund the credit to the learner's enterprise account. Do you wish to
+        continue?
+    </h3>
+    <div style="display:flex";>
+        <div style="vertical-align:top">
+            <input type="hidden" name="post" value="submit" />
+            <input type="hidden" name="action" value="submit" />
+            <input type="submit" value="Confirm with refund" />
+        </div>
+        <div style="margin-left:0.5rem">
+            <input type="button" value="Cancel" onclick="history.go(-1)"/>
+        </div>
+    </div>
+</form>
+{% endblock %}
+

--- a/openedx_ledger/tests/test_views.py
+++ b/openedx_ledger/tests/test_views.py
@@ -1,0 +1,114 @@
+"""
+Tests for the base views in the openedx_ledger app
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from django.contrib.auth.models import User  # pylint: disable=imported-auth-user
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from openedx_ledger.models import Reversal
+from openedx_ledger.signals.signals import TRANSACTION_REVERSED
+from openedx_ledger.test_utils.factories import LedgerFactory, ReversalFactory, TransactionFactory
+
+
+@pytest.mark.django_db
+class ViewTestBases(APITestCase, TestCase):
+    """
+    Base class for view tests, includes helper methods for creating test data and formatting urls
+    """
+
+    def setUp(self):
+        super().setUp()
+        # User.objects.get_or_create(username='testuser')[0]
+        self.client.force_login(User.objects.get_or_create(username='testuser', is_superuser=True, is_staff=True)[0])
+
+        self.ledger = LedgerFactory()
+        self.fulfillment_identifier = 'foobar'
+        self.transaction = TransactionFactory(
+            ledger=self.ledger,
+            quantity=100,
+            fulfillment_identifier=self.fulfillment_identifier
+        )
+
+    def get_reverse_transaction_url(self, transaction_id):
+        """
+        helper method to get the url for the reverse transaction view
+        """
+        return reverse('admin:reverse_transaction', args=(transaction_id,))
+
+
+@pytest.mark.django_db
+class ReverseTransactionViewTests(ViewTestBases):
+    """
+    Tests for the reverse transaction view
+    """
+
+    def test_reverse_transaction_view_get(self):
+        """
+        Test expected behaviors of the reverse transaction view get request
+        """
+        url = self.get_reverse_transaction_url(self.transaction.uuid)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        # Assert that the reversal confirmation form is returned in the get response
+        assert b'This action will unenroll the learner AND refund the credit' in response.content
+
+    def test_reverse_transaction_view_post(self):
+        """
+        Test expected behaviors of posting to the reverse transaction view
+        """
+        signal_received = MagicMock()
+        TRANSACTION_REVERSED.connect(signal_received)
+
+        # Assert that no Transaction Reversal objects exist
+        assert Reversal.objects.count() == 0
+        url = self.get_reverse_transaction_url(self.transaction.uuid)
+        response = self.client.post(url)
+        # Assert that a successful post will redirect to the admin transaction editing page
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f'/admin/openedx_ledger/transaction/{self.transaction.uuid}/change/')
+
+        # Assert that the transaction reversal was created
+        self.assertEqual(self.transaction.reversal, Reversal.objects.first())
+
+        # Assert that the transaction reversal signal was sent and received
+        signal_received.assert_called()
+
+    def test_reverse_transaction_view_post_with_existing_reversal(self):
+        """
+        Test expected behaviors of POSTing to the reverse transaction view when a reversal already exists
+        """
+        signal_received = MagicMock()
+        TRANSACTION_REVERSED.connect(signal_received)
+
+        assert Reversal.objects.count() == 0
+        ReversalFactory(transaction=self.transaction)
+
+        url = self.get_reverse_transaction_url(self.transaction.uuid)
+        response = self.client.post(url)
+
+        # Assert that the post request returns a 400 status code
+        self.assertEqual(response.status_code, 400)
+        # Assert that the response contains the expected error message
+        self.assertEqual(response.content, b'Transaction Reversal already exists')
+
+        # Assert that the transaction reversal signal was not sent or received
+        signal_received.assert_not_called()
+
+    def test_reverse_transaction_view_get_with_reversal_already_exists(self):
+        """
+        Test expected behaviors of the reverse transaction view GET request when a reversal already exists
+        """
+        assert Reversal.objects.count() == 0
+        ReversalFactory(transaction=self.transaction)
+
+        url = self.get_reverse_transaction_url(self.transaction.uuid)
+        response = self.client.get(url)
+
+        # Assert that the get request returns a 400 status code
+        self.assertEqual(response.status_code, 400)
+        # Assert that the response contains the expected error message
+        self.assertEqual(response.content, b'Transaction Reversal already exists')

--- a/openedx_ledger/urls.py
+++ b/openedx_ledger/urls.py
@@ -1,10 +1,12 @@
 """
 URLs for openedx_ledger.
 """
-from django.urls import re_path  # pylint: disable=unused-import
+from django.contrib import admin
+from django.urls import path, re_path  # pylint: disable=unused-import
 from django.views.generic import TemplateView  # pylint: disable=unused-import
 
 urlpatterns = [
     # TODO: Fill in URL patterns and views here.
     # re_path(r'', TemplateView.as_view(template_name="openedx_ledger/base.html")),
+    path('admin/', admin.site.urls)
 ]

--- a/openedx_ledger/views.py
+++ b/openedx_ledger/views.py
@@ -1,6 +1,73 @@
 """
 Views for the openedx_ledger app.
 """
-# from django.shortcuts import render
+import logging
 
-# Create your views here.
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.utils import IntegrityError
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.generic import View
+
+from openedx_ledger.api import reverse_full_transaction
+from openedx_ledger.models import Transaction
+
+logger = logging.getLogger(__name__)
+
+
+class ReverseTransactionView(View):
+    """
+    Admin view for the form responsible for reversing transaction objects and emitting an unenrollment signal.
+    """
+    template = "edx_ledger/admin/reverse_transaction.html"
+
+    def get(self, request, transaction_id):
+        """
+        Handle GET request - render "Reverse Transaction" form.
+
+        Arguments:
+            request (django.http.request.HttpRequest): Request instance
+            transaction_uuid (str): Enterprise Customer UUID
+
+        Returns:
+            django.http.response.HttpResponse: HttpResponse
+        """
+        transaction = Transaction.objects.get(uuid=transaction_id)
+        try:
+            if transaction.reversal:
+                logger.info(
+                    f"ReverseTransactionView Error: transaction reversal already exists: {transaction_id}"
+                )
+                return HttpResponseBadRequest('Transaction Reversal already exists')
+        except ObjectDoesNotExist:
+            pass
+
+        return render(
+            request,
+            self.template,
+            {'transaction': transaction}
+        )
+
+    def post(self, request, transaction_id):
+        """
+        Handle POST request - handle form submissions.
+        """
+        logger.info(
+            "Reversing transaction and sending admin invoked transaction unenroll signal for transaction: "
+            f"{transaction_id}"
+        )
+        transaction = Transaction.objects.get(uuid=transaction_id)
+        # TODO: determine how to generate idempotency key
+        try:
+            reverse_full_transaction(
+                transaction,
+                idempotency_key=f"admin-invoked-reverse-{str(transaction.uuid)}"
+            )
+        except IntegrityError:
+            logger.exception(
+                f"ReverseTransactionView Error: transaction reversal already exists: {transaction_id}"
+            )
+            return HttpResponseBadRequest('Transaction Reversal already exists')
+        url = reverse("admin:openedx_ledger_transaction_change", args=(transaction_id,))
+        return HttpResponseRedirect(url)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,7 @@ Django             # Web application framework
 djangoql
 django-extensions
 django-filter
+django-object-actions
 django-simple-history
 edx-django-utils
 edx-django-release-util

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,6 +48,8 @@ django-filter==23.1
     # via -r requirements/base.in
 django-model-utils==4.3.1
     # via edx-rbac
+django-object-actions==4.1.0
+    # via -r requirements/base.in
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ filelock==3.12.0
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.2.0
+platformdirs==3.3.0
     # via virtualenv
 pluggy==1.0.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -109,6 +109,8 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/quality.txt
     #   edx-rbac
+django-object-actions==4.1.0
+    # via -r requirements/quality.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -156,7 +158,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==18.4.0
+faker==18.5.1
     # via
     #   -r requirements/quality.txt
     #   factory-boy
@@ -228,7 +230,7 @@ pbr==5.11.1
     #   stevedore
 pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.2.0
+platformdirs==3.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -278,7 +280,7 @@ pyjwt[crypto]==2.6.0
     #   -r requirements/quality.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -90,6 +90,8 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
+django-object-actions==4.1.0
+    # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -142,7 +144,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.4.0
+faker==18.5.1
     # via
     #   -r requirements/test.txt
     #   factory-boy

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.1
     # via -r requirements/pip.in
-setuptools==67.7.1
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.3
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
@@ -87,6 +87,8 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/test.txt
     #   edx-rbac
+django-object-actions==4.1.0
+    # via -r requirements/test.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -132,7 +134,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.4.0
+faker==18.5.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -186,7 +188,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.2.0
+platformdirs==3.3.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -221,7 +223,7 @@ pyjwt[crypto]==2.6.0
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.17.2
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -72,6 +72,8 @@ django-model-utils==4.3.1
     # via
     #   -r requirements/base.txt
     #   edx-rbac
+django-object-actions==4.1.0
+    # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -113,7 +115,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.4.0
+faker==18.5.1
     # via factory-boy
 fastavro==1.7.3
     # via

--- a/test_settings.py
+++ b/test_settings.py
@@ -4,8 +4,10 @@ These settings are here to use during tests, because django requires them.
 In a real-world use case, apps in this project are installed into other
 Django applications, so these settings will not be used.
 """
-
+import os
 from os.path import abspath, dirname, join
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
 def root(*args):
@@ -44,16 +46,24 @@ ROOT_URLCONF = 'openedx_ledger.urls'
 
 SECRET_KEY = 'insecure-secret-key'
 
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+}
+
 MIDDLEWARE = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
     'simple_history.middleware.HistoryRequestMiddleware',
 )
 
 TEMPLATES = [{
     'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    'APP_DIRS': False,
+    'DIRS': [os.path.join(BASE_DIR, "/templates")],
+    'APP_DIRS': True,
     'OPTIONS': {
         'context_processors': [
             'django.contrib.auth.context_processors.auth',  # this is required for admin


### PR DESCRIPTION
**Description:**
Reasons behind the change: https://2u-internal.atlassian.net/browse/ENT-6935

TLDR - we need a way for support admins to revoke platform enrollment objects and choose whether or not to reverse the transaction object within the subsidy/ledger service. 

In implementing this we found the need to allow consumers to hook into certain events that can occur within the ledger models and services. As such I've added signals for un-enrollment related admin template/views and transaction reversal actions. In this way, the subsidy service can implement a receiver and use it's enterprise api client to update the appropriate LMS records upon the triggering of the appropriate admin unenroll event.      

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
