### PR TITLE
fix: reversals now have a "committed" steady-state

### DIFF
--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,6 +1,6 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 default_app_config = "openedx_ledger.apps.EdxLedgerConfig"

--- a/openedx_ledger/api.py
+++ b/openedx_ledger/api.py
@@ -24,7 +24,7 @@ def create_transaction(
     **metadata
 ):
     """
-    Create a transaction.
+    Create a pending transaction.
 
     Args:
         ledger (openedx_ledger.models.Ledger): The ledger to which the transaction should be added.
@@ -93,6 +93,7 @@ def reverse_full_transaction(transaction, idempotency_key, **metadata):
                 'quantity': transaction.quantity * -1,
                 'metadata': metadata,
             },
+            state=models.TransactionStateChoices.COMMITTED,
         )
         TRANSACTION_REVERSED.send(sender=models.Reversal, reversal=reversal)
         return reversal

--- a/openedx_ledger/models.py
+++ b/openedx_ledger/models.py
@@ -153,6 +153,8 @@ class Ledger(TimeStampedModelWithUuid):
         """
         Calculate the current balance of the ledger.
 
+        TODO: propagate committed_only down into the reversals too.
+
         Args:
             committed_only (boolean): If true, computes balance only for `committed` transations.  Defaults to False.
 

--- a/openedx_ledger/test_utils/factories.py
+++ b/openedx_ledger/test_utils/factories.py
@@ -39,7 +39,7 @@ class TransactionFactory(factory.django.DjangoModelFactory):
 
     uuid = factory.LazyFunction(uuid4)
     idempotency_key = factory.LazyFunction(uuid4)
-    state = TransactionStateChoices.CREATED
+    state = TransactionStateChoices.COMMITTED
     quantity = factory.Faker("random_int", min=-100000, max=-100)
     ledger = factory.Iterator(Ledger.objects.all())
     lms_user_id = factory.Faker("random_int", min=1, max=1000)
@@ -78,5 +78,5 @@ class ReversalFactory(factory.django.DjangoModelFactory):
     uuid = factory.LazyFunction(uuid4)
     transaction = factory.Iterator(Transaction.objects.all())
     idempotency_key = factory.LazyFunction(uuid4)
-    state = TransactionStateChoices.CREATED
+    state = TransactionStateChoices.COMMITTED
     quantity = factory.Faker("random_int", min=100, max=10000)


### PR DESCRIPTION
Reversals at-rest should have state="committed".  The way we had it before, all reversals became state="created" forever.

In support of ENT-7204