### PR TITLE
feat: make transaction and ledger admins friendlier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,11 @@ Change Log
 
 Unreleased
 **********
+* Nothing unreleased
 
+[1.0.1]
+*******
+* make transaction and ledger admins friendlier
 
 [1.0.0]
 *******

--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,6 +1,6 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 default_app_config = "openedx_ledger.apps.EdxLedgerConfig"

--- a/openedx_ledger/constants.py
+++ b/openedx_ledger/constants.py
@@ -1,6 +1,7 @@
 """
 Constants for the openedx_ledger app.
 """
+CENTS_PER_US_DOLLAR = 100
 LEDGER_DEFAULT_IDEMPOTENCY_KEY_PREFIX = 'ledger-default'
 LEDGERED_SUBSIDY_IDEMPOTENCY_KEY_PREFIX = 'ledger-for-subsidy'
 

--- a/openedx_ledger/models.py
+++ b/openedx_ledger/models.py
@@ -352,6 +352,16 @@ class Transaction(BaseTransaction):
     )
     history = HistoricalRecords()
 
+    def get_reversal(self):
+        """
+        Convenience method for fetching this transaction's related
+        reversal, or None if no such reversal exists.
+        """
+        try:
+            return self.reversal
+        except Reversal.DoesNotExist:
+            return None
+
 
 class ExternalFulfillmentProvider(TimeStampedModel):
     """


### PR DESCRIPTION
Minor quality-of-life improvements.

Now the transaction details page allow edits to `fulfillment_identifier`
<img width="1165" alt="image" src="https://github.com/openedx/openedx-ledger/assets/2307986/e496de71-5b18-4b17-b86f-2e31f74bac67">

Ledger details now shows the balance as a USD string
<img width="473" alt="image" src="https://github.com/openedx/openedx-ledger/assets/2307986/3ae7e1ad-a716-42a1-9618-7a25833e4037">

Transaction list display now shows values that help us debug:
<img width="1487" alt="image" src="https://github.com/openedx/openedx-ledger/assets/2307986/50bd1964-f192-4732-9e9d-c477e39f846b">


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
