### PR TITLE
chore: only allow reversals of committed transactions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 **********
 * Nothing unreleased
 
+[1.0.2]
+*******
+* only allow reversals of committed transactions
+
 [1.0.1]
 *******
 * make transaction and ledger admins friendlier

--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,6 +1,6 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 default_app_config = "openedx_ledger.apps.EdxLedgerConfig"

--- a/openedx_ledger/models.py
+++ b/openedx_ledger/models.py
@@ -358,7 +358,7 @@ class Transaction(BaseTransaction):
         reversal, or None if no such reversal exists.
         """
         try:
-            return self.reversal
+            return self.reversal  # pylint: disable=no-member
         except Reversal.DoesNotExist:
             return None
 

--- a/openedx_ledger/views.py
+++ b/openedx_ledger/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import View
 
-from openedx_ledger.api import reverse_full_transaction
+from openedx_ledger.api import NonCommittedTransactionError, reverse_full_transaction
 from openedx_ledger.models import Transaction
 
 logger = logging.getLogger(__name__)
@@ -69,5 +69,10 @@ class ReverseTransactionView(View):
                 f"ReverseTransactionView Error: transaction reversal already exists: {transaction_id}"
             )
             return HttpResponseBadRequest('Transaction Reversal already exists')
+        except NonCommittedTransactionError as error:
+            logger.exception(
+                f"ReverseTransactionView Error: transaction is not in a committed state: {transaction_id}"
+            )
+            return HttpResponseBadRequest(f'Transaction Reversal failed: {error}')
         url = reverse("admin:openedx_ledger_transaction_change", args=(transaction_id,))
         return HttpResponseRedirect(url)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,9 @@ def test_create_ledger_happy_path():
     tx_2 = api.create_transaction(ledger, quantity=5000, idempotency_key='tx-2', state=TransactionStateChoices.CREATED)
     assert ledger.balance() == 10000
 
+    tx_2.state = TransactionStateChoices.COMMITTED
+    tx_2.save()
+
     api.reverse_full_transaction(tx_2, idempotency_key='reversal-1')
     assert ledger.balance() == 5000
 
@@ -51,6 +54,9 @@ def test_multiple_reversals():
 
     tx_1 = api.create_transaction(ledger, quantity=5000, idempotency_key='tx-1', state=TransactionStateChoices.CREATED)
     assert ledger.balance() == 5000
+
+    tx_1.state = TransactionStateChoices.COMMITTED
+    tx_1.save()
 
     reversal = api.reverse_full_transaction(tx_1, idempotency_key='reversal-1')
     assert ledger.balance() == 0


### PR DESCRIPTION
**Description:**
If a transaction is not in a COMMITTED state in Django admin, an error screen is shown to prevent reversals or unenrollments.
[Jira ticket](https://2u-internal.atlassian.net/browse/ENT-7315)
<img width="946" alt="Screenshot 2023-07-07 at 10 05 10 AM" src="https://github.com/openedx/openedx-ledger/assets/129111440/5618e96e-3cf6-4a1c-bd32-3b4a4ab45e44">


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
