### PR TITLE
chore: move raises docstring to proper method

### DIFF
--- a/openedx_ledger/api.py
+++ b/openedx_ledger/api.py
@@ -56,8 +56,6 @@ def create_transaction(
             Raises this if there's another attempt in process to add a transaction to this Ledger.
         openedx_ledger.api.LedgerBalanceExceeded:
             Raises this if the transaction would cause the balance of the ledger to become negative.
-        openedx_ledger.api.NonCommittedTransactionError:
-            Raises this if the transaction is not in a COMMITTED state.
     """
     with ledger.lock():
         durable = not get_connection().in_atomic_block
@@ -88,6 +86,8 @@ def reverse_full_transaction(transaction, idempotency_key, **metadata):
     Idempotency of reversals - reversing the same transaction twice
     produces the same output and has no side effect on the second invocation.
     Support idempotency key here, too.
+    openedx_ledger.api.NonCommittedTransactionError:
+        Raises this if the transaction is not in a COMMITTED state.
     """
     with atomic(durable=True):
         # select the transaction and any reversals


### PR DESCRIPTION
**Description:**
In the work for https://2u-internal.atlassian.net/browse/ENT-7315, I added a `raises` docstring on the wrong method. I'm moving it to the correct spot here.


**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
