### PR TITLE
build: codecov shouldn't fail ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         flags: unittests
-        fail_ci_if_error: true
+        fail_ci_if_error: false


### PR DESCRIPTION
Don't fail CI if codecov fails.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
