### PR TITLE
feat: Add data migration to backfill legacy initial deposits

### DIFF
--- a/openedx_ledger/migrations/0012_backfill_initial_deposits.py
+++ b/openedx_ledger/migrations/0012_backfill_initial_deposits.py
@@ -1,0 +1,42 @@
+"""
+Backfill initial deposits.
+
+Note this has no reverse migration logic. Attempts to rollback the deployment which includes this PR will not delete
+(un-backfill) the deposits created during the forward migration.
+"""
+from django.db import migrations
+
+from openedx_ledger.utils import find_legacy_initial_transactions
+
+
+def forwards_func(apps, schema_editor):
+    """
+    The core logic of this migration.
+    """
+    # We get the model from the versioned app registry; if we directly import it, it'll be the wrong version.
+    Transaction = apps.get_model("openedx_ledger", "Transaction")
+    Deposit = apps.get_model("openedx_ledger", "Deposit")
+
+    # Fetch all "legacy" initial transactions
+    legacy_initial_transactions = find_legacy_initial_transactions(Transaction).values("uuid", "quantity")
+    deposits_to_backfill = (
+        Deposit(
+            transaction=tx["uuid"],
+            desired_deposit_quantity=tx["quantity"],
+        )
+        for tx in legacy_initial_transactions
+    )
+    Deposit.bulk_create(deposits_to_backfill)
+
+
+class Migration(migrations.Migration):
+    """
+    Migration for backfilling initial deposits.
+    """
+    dependencies = [
+        ("openedx_ledger", "0011_deposit_models"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func),
+    ]

--- a/openedx_ledger/models.py
+++ b/openedx_ledger/models.py
@@ -13,10 +13,12 @@ from edx_django_utils.cache.utils import get_cache_key
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
+from simple_history.utils import bulk_create_with_history
 
 from openedx_ledger.utils import create_idempotency_key_for_ledger
 
 LEDGER_LOCK_RESOURCE_NAME = 'ledger'
+BULK_OPERATION_BATCH_SIZE = 50
 
 
 class UnitChoices:
@@ -735,3 +737,15 @@ class Deposit(TimeStampedModelWithUuid):
         )
     )
     history = HistoricalRecords()
+
+    @classmethod
+    def bulk_create(cls, deposit_records):
+        """
+        Creates new ``Deposit`` records in bulk, while saving their history:
+        https://django-simple-history.readthedocs.io/en/latest/common_issues.html#bulk-creating-a-model-with-history
+        """
+        return bulk_create_with_history(
+            deposit_records,
+            cls,
+            batch_size=BULK_OPERATION_BATCH_SIZE,
+        )

--- a/openedx_ledger/utils.py
+++ b/openedx_ledger/utils.py
@@ -4,6 +4,11 @@ Common utility functions that don't create/update/destroy business objects.
 import hashlib
 from uuid import uuid4
 
+from django.db.models import F, Window
+from django.db.models.functions import FirstValue
+
+from openedx_ledger.models import Transaction
+
 from .constants import (
     INITIAL_DEPOSIT_TRANSACTION_SLUG,
     LEDGER_DEFAULT_IDEMPOTENCY_KEY_PREFIX,
@@ -46,3 +51,35 @@ def create_idempotency_key_for_transaction(ledger, quantity, is_initial_deposit=
         }
     hashed_metadata = hashlib.md5(str(idpk_data).encode()).hexdigest()
     return f'{ledger.idempotency_key}-{quantity}-{hashed_metadata}'
+
+
+def find_legacy_initial_transactions():
+    """
+    Heuristic to identify "legacy" initial transactions.
+
+    An initial transaction is one that has the following traits:
+    * Is chronologically the first transaction for a Ledger.
+    * Contains a hint in its idempotency key which indicates that it is an initial deposit.
+    * Has a positive quantity.
+
+    A legacy initial transaction is one that has the following additional traits:
+    * does not have a related Deposit.
+    """
+    # All transactions which are chronologically the first in their respective ledgers.
+    first_transactions = Transaction.objects.annotate(
+        first_tx_uuid=Window(
+            expression=FirstValue('uuid'),
+            partition_by=['ledger'],
+            order_by=F('created').asc(),  # "first chronologically" above means first created.
+        ),
+    ).filter(uuid=F('first_tx_uuid'))
+
+    # Further filter first_transactions to find ones that qualify as _initial_ and _legacy_.
+    legacy_initial_transactions = first_transactions.filter(
+        # Traits of an _initial_ deposit:
+        idempotency_key__contains=INITIAL_DEPOSIT_TRANSACTION_SLUG,
+        quantity__gte=0,
+        # Traits of a _legacy_ initial deposit:
+        deposit__isnull=True,
+    )
+    return legacy_initial_transactions

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,8 @@ from itertools import chain, combinations
 from django.test import TestCase
 
 from openedx_ledger import utils
-from openedx_ledger.test_utils.factories import LedgerFactory
+from openedx_ledger.constants import INITIAL_DEPOSIT_TRANSACTION_SLUG
+from openedx_ledger.test_utils.factories import AdjustmentFactory, DepositFactory, LedgerFactory, TransactionFactory
 
 
 def powerset(iterable):
@@ -71,3 +72,47 @@ class TransactionIdempotencyKeyTests(TestCase):
             ledger, quantity=100, is_initial_deposit=True,
         )
         assert 'ledger-key-100-initial-deposit' == key
+
+
+class MigrationUtilsTests(TestCase):
+    """
+    Tests for utils used for migrations.
+    """
+    def test_find_legacy_initial_transactions(self):
+        """
+        Test find_legacy_initial_transactions(), used for a data migration to backfill initial deposits.
+        """
+        ledgers = [
+            (LedgerFactory(), False),
+            (LedgerFactory(), False),
+            (LedgerFactory(), True),
+            (LedgerFactory(), False),
+            (LedgerFactory(), True),
+        ]
+        expected_legacy_initial_transactions = []
+        for ledger, create_initial_deposit in ledgers:
+            # Simulate a legacy initial transaction (i.e. transaction WITHOUT a deposit).
+            initial_transaction = TransactionFactory(
+                ledger=ledger,
+                idempotency_key=INITIAL_DEPOSIT_TRANSACTION_SLUG,
+                quantity=100,
+            )
+            if create_initial_deposit:
+                # Make it a modern initial deposit by creating a related Deposit.
+                DepositFactory(
+                    ledger=ledger,
+                    transaction=initial_transaction,
+                    desired_deposit_quantity=initial_transaction.quantity,
+                )
+            else:
+                # Keep it a legacy initial deposit by NOT creating a related Deposit.
+                expected_legacy_initial_transactions.append(initial_transaction)
+            # Throw in a few spend, deposit, and adjustment transactions for fun.
+            TransactionFactory(ledger=ledger, quantity=-10)
+            TransactionFactory(ledger=ledger, quantity=-10)
+            DepositFactory(ledger=ledger, desired_deposit_quantity=50)
+            tx_to_adjust = TransactionFactory(ledger=ledger, quantity=-5)
+            AdjustmentFactory(ledger=ledger, adjustment_quantity=5, transaction_of_interest=tx_to_adjust)
+
+        actual_legacy_initial_transactions = utils.find_legacy_initial_transactions()
+        assert set(actual_legacy_initial_transactions) == set(expected_legacy_initial_transactions)


### PR DESCRIPTION
Add a data migration to backfill deposits for initial transactions that are missing a deposit.

ENT-9075