### PR TITLE
chore: Update python requirements job source to openedx

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -21,4 +21,4 @@ jobs:
        requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
        edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
        edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}
-    uses: edx/.github/.github/workflows/upgrade-python-requirements.yml@master
+    uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 **********
 * Nothing unreleased
 
+[1.5.22]
+********
+* chore: Update python requirements job source to openedx
+
 [1.5.21]
 ********
 * chore: Increase version to 1.5.21 for dependency updates.

--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,4 +1,4 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "1.5.21"
+__version__ = "1.5.22"


### PR DESCRIPTION
**Description:**
Updates the source from which the python requirements upgrade are run from edx to openedx. This matches the pattern that exist within our other enterprise repos and resolves the failing python requirements upgrade action. 

**Testing instructions:**
Add some.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
