### PR TITLE
chore: bump version to 1.5.23 for python upgrades

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 **********
 * Nothing unreleased
 
+[1.5.23]
+********
+* chore: Increase version to 1.5.23 for dependency updates.
+
 [1.5.22]
 ********
 * chore: Update python requirements job source to openedx

--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,4 +1,4 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "1.5.22"
+__version__ = "1.5.23"


### PR DESCRIPTION
**Description:**
Bumps version to 1.5.23 for python upgrades.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
