### PR TITLE
feat: ENT-10825 Persist Start Date on the Transaction Model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 **********
 * Nothing unreleased
 
+[1.6.9]
+*******
+* feat: Added `course_run_start_date` field to the `Transaction` model.
+
 [1.6.8]
 *******
 * chore: Increase version to 1.6.8 for dependency updates.

--- a/openedx_ledger/__init__.py
+++ b/openedx_ledger/__init__.py
@@ -1,4 +1,4 @@
 """
 A library that records transactions against a ledger, denominated in units of value.
 """
-__version__ = "1.6.8"
+__version__ = "1.6.9"

--- a/openedx_ledger/api.py
+++ b/openedx_ledger/api.py
@@ -58,6 +58,7 @@ def create_transaction(
     content_key=None,
     parent_content_key=None,
     content_title=None,
+    course_run_start_date=None,
     subsidy_access_policy_uuid=None,
     state=models.TransactionStateChoices.CREATED,
     **metadata
@@ -84,6 +85,9 @@ def create_transaction(
         content_title (str, Optional):
             The title of the content into which the learner is enrolling. Skip if this does not represent a policy
             enrolling a learner into content or if the title is not readily available.
+        course_run_start_date (datetime, Optional):
+            The start date of the course run associated with this transaction. Skip if this does not represent a policy
+            enrolling a learner into content or if the start date is not readily available.
         subsidy_access_policy_uuid (str, Optional):
             The policy which permitted the creation of the new Transaction. Skip if this does not represent a policy
             enrolling a learner into content.
@@ -114,6 +118,7 @@ def create_transaction(
                     "content_key": content_key,
                     "parent_content_key": parent_content_key,
                     "content_title": content_title,
+                    "course_run_start_date": course_run_start_date,
                     "lms_user_id": lms_user_id,
                     "lms_user_email": lms_user_email,
                     "subsidy_access_policy_uuid": subsidy_access_policy_uuid,

--- a/openedx_ledger/migrations/0015_add_course_run_start_date_to_transaction.py
+++ b/openedx_ledger/migrations/0015_add_course_run_start_date_to_transaction.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('openedx_ledger', '0014_rename_transaction_ledger_content_key_openedx_led_ledger__4c90f0_idx_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicaltransaction',
+            name='course_run_start_date',
+            field=models.DateTimeField(blank=True, db_index=True, help_text='The start date of the course run associated with this Transaction. The start date is captured at the time the Transaction is created and may not be up to date.', null=True),
+        ),
+        migrations.AddField(
+            model_name='transaction',
+            name='course_run_start_date',
+            field=models.DateTimeField(blank=True, db_index=True, help_text='The start date of the course run associated with this Transaction. The start date is captured at the time the Transaction is created and may not be up to date.', null=True),
+        ),
+    ]

--- a/openedx_ledger/models.py
+++ b/openedx_ledger/models.py
@@ -414,6 +414,15 @@ class Transaction(BaseTransaction):
             "The title is captured at the time the Transaction is created and may not be up to date."
         )
     )
+    course_run_start_date = models.DateTimeField(
+        blank=True,
+        null=True,
+        db_index=True,
+        help_text=(
+            "The start date of the course run associated with this Transaction."
+            "The start date is captured at the time the Transaction is created and may not be up to date."
+        )
+    )
     fulfillment_identifier = models.CharField(
         max_length=255,
         blank=True,

--- a/openedx_ledger/test_utils/factories.py
+++ b/openedx_ledger/test_utils/factories.py
@@ -50,6 +50,7 @@ class TransactionFactory(factory.django.DjangoModelFactory):
     content_key = factory.LazyAttribute(lambda tx: f"course-v1:{tx.parent_content_key}+2023")
     parent_content_key = factory.Faker("lexify", text="???+?????101")
     content_title = factory.Faker("lexify", text="???: ?????? ???")
+    course_run_start_date = factory.Faker("future_datetime", end_date="+180d")
 
 
 class ExternalFulfillmentProviderFactory(factory.django.DjangoModelFactory):

--- a/test_settings.py
+++ b/test_settings.py
@@ -44,6 +44,8 @@ LOCALE_PATHS = [
 
 ROOT_URLCONF = 'openedx_ledger.urls'
 
+USE_TZ = True
+
 SECRET_KEY = 'insecure-secret-key'
 
 REST_FRAMEWORK = {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,9 +3,11 @@
 Tests for the `openedx-ledger` models.
 """
 import uuid
+from datetime import datetime
 
 import ddt
 import pytest
+import pytz
 from django.test import TestCase
 
 from openedx_ledger import models
@@ -161,6 +163,18 @@ class LedgerBalanceTests(TestCase):
         my_ledger.save()
 
         self.assertIsNotNone(my_ledger.idempotency_key)
+
+    def test_course_run_start_date_is_saved(self):
+        """
+        Test that course_run_start_date is saved and retrieved correctly on Transaction.
+        """
+        start_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=pytz.UTC)
+        transaction = TransactionFactory(
+            ledger=self.ledger,
+            course_run_start_date=start_date,
+        )
+        transaction.refresh_from_db()
+        self.assertEqual(transaction.course_run_start_date, start_date)
 
 
 class LedgerLockTests(TestCase):


### PR DESCRIPTION
**Description:**
Adds a new field `course_run_start_date` to the Transaction model.
[ENT-10825](https://2u-internal.atlassian.net/browse/ENT-10825)

**Testing instructions:**
Check database table to see if field was created.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
