### PR TITLE
chore: change the cron schedule to run on friday instead of monday

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Requirements
 
 on:
   schedule:
-     - cron: "0 2 * * 1"
+     - cron: "0 2 * * 5"
   workflow_dispatch:
      inputs:
        branch:


### PR DESCRIPTION
**Description:**
Move all the make upgrade Github jobs to Friday instead of Monday.

**Jira ticket:**
[ENT-11931](https://2u-internal.atlassian.net/browse/ENT-11931)

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPI after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
