### PR TITLE
chore: upgrade codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,8 @@ jobs:
 
     - name: Run coverage
       if: matrix.python-version == '3.12' && matrix.toxenv == 'django52'
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         fail_ci_if_error: true
-        use_pypi: true


### PR DESCRIPTION
**Description:**
Upgrade `codecov/codecov-action` in CI to `v7` and remove the temporary `use_pypi: true` workaround in `.github/workflows/ci.yml`.

**Jira:**
ENT-11952

**Changes**
- update `.github/workflows/ci.yml`
- change `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe` to `codecov/codecov-action@v7`
- remove `use_pypi: true`